### PR TITLE
Don't warn for vars-on-top by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ module.exports = {
 		'spaced-comment':                'error',
 		'template-curly-spacing':        'error',
 		'valid-jsdoc':                   [ 'warn', { 'requireReturn': false, 'requireReturnDescription': false } ],
-		'vars-on-top':                   'warn',
+		'vars-on-top':                   'off',
 		'wrap-iife':                     'error',
 		'yield-star-spacing':            'error',
 		'yoda':                          'error',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-axway",
-	"version": "2.0.3",
+	"version": "2.0.4",
 	"description": "Shareable eslint config for Axway projects",
 	"license": "Apache-2.0",
 	"repository": {


### PR DESCRIPTION
This is a large enough pain that it should be disabled by default; if someone really wants it they can opt in inside their own ESLint configuration.