### PR TITLE
Improve bracket spacing rules when nesting objects/arrays on new lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = {
 	'rules': {
 		// eslint recommended overrides
 		'accessor-pairs':                'error',
-		'array-bracket-spacing':         [ 'error', 'always' ],
+		'array-bracket-spacing':         [ 'error', 'always' { 'objectsInArrays': false, 'arraysInArrays': false } ],
 		'array-callback-return':         'error',
 		'arrow-parens':                  'off',
 		'arrow-spacing':                 [ 'error', { 'after': true, 'before': true } ],


### PR DESCRIPTION
The current rules complain about code like this:

```
const foo = [{
  'bar': 'baz'
}]
```
It wants it to look like this: Pretty ugly?
```
const foo = [ {
  'bar': 'baz'
} ]
```

The downside is arguably that you lose the spacing on single line objects/arrays such as this, but can't find a rule specifically for disabling bracket spacing when going multiline.
```
const foo = [{ 'foo: 'bar'}];
```