### PR TITLE
add experimentalObjectRestSpread to default node config for node 8+ users

### DIFF
--- a/env-node.js
+++ b/env-node.js
@@ -2,5 +2,10 @@ module.exports = {
 	'env': {
 		'node': true
 	},
+	'parserOptions': {
+		'ecmaFeatures': {
+			'experimentalObjectRestSpread': true
+		}
+	},
 	'extends': './index.js'
 };


### PR DESCRIPTION
Users of newer node versions don't need babel to get the object rest spread feature. 