### PR TITLE
Unbreak things

### DIFF
--- a/+chai.js
+++ b/+chai.js
@@ -5,10 +5,15 @@ verifyPeer('eslint-plugin-chai-friendly');
 
 module.exports = {
 	'plugins': [
-		'chai-friendly'
+		'chai-expect', // https://www.npmjs.com/package/eslint-plugin-chai-expect
+		'chai-friendly' // https://www.npmjs.com/package/eslint-plugin-chai-friendly
 	],
 	'rules': {
 		'no-unused-expressions': 'off',
-		'chai-friendly/no-unused-expressions': [ 'error', { 'allowShortCircuit': true, 'allowTernary': true } ]
+		'chai-friendly/no-unused-expressions': [ 'error', { 'allowShortCircuit': true, 'allowTernary': true } ],
+
+		// chai rules
+		'chai-expect/missing-assertion': 'warn', // TODO: Bump to error in next major
+		'chai-expect/terminating-properties': 'warn',
 	}
 };

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ module.exports = {
 		'sourceType': 'module'
 	},
 	'plugins': [
-		'chai-expect', // https://www.npmjs.com/package/eslint-plugin-chai-expect
 		'import',      // https://www.npmjs.com/package/eslint-plugin-import
 		'promise',     // https://www.npmjs.com/package/eslint-plugin-promise
 		'security'     // https://www.npmjs.com/package/eslint-plugin-security
@@ -197,22 +196,18 @@ module.exports = {
 		'security/detect-object-injection':        'off',
 		'security/detect-unsafe-regex':            'off',
 
-		// chai rules
-		'chai-expect/missing-assertion': 'error',
-		'chai-expect/terminating-properties': 'warn',
-
 		// promise rules
-		'promise/always-return': 'error',
+		'promise/always-return': 'warn', // TODO: Bump to error in next major
 		'promise/avoid-new': 'off',
-		'promise/catch-or-return': 'error',
+		'promise/catch-or-return': 'warn', // TODO: Bump to error in next major
 		'promise/no-callback-in-promise': 'warn',
 		'promise/no-native': 'off',
 		'promise/no-nesting': 'warn',
-		'promise/no-new-statics': 'error',
+		'promise/no-new-statics': 'warn', // TODO: Bump to error in next major
 		'promise/no-promise-in-callback': 'warn',
 		'promise/no-return-in-finally': 'warn',
-		'promise/no-return-wrap': 'error',
-		'promise/param-names': 'error',
+		'promise/no-return-wrap': 'warn', // TODO: Bump to error in next major
+		'promise/param-names': 'warn', // TODO: Bump to error in next major
 		'promise/valid-params': 'warn'
 	}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-axway",
-	"version": "4.1.0",
+	"version": "4.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-axway",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"description": "Shareable eslint config for Axway projects",
 	"license": "Apache-2.0",
 	"repository": {


### PR DESCRIPTION
There's about 5 repos broke by the new rules not sure if any other teams are affected, if new rules are introduced in a minor they should only be **warn** and then bumped in the next major.

I've also moved the chai rules to be in the `chai.js` file, the package should also be a optionalDependency

* [karma-titanium-launcher](https://github.com/appcelerator/karma-titanium-launcher/issues/15)
* [titanized](https://github.com/appcelerator/titanized/issues/7)
* [titanium-karma-client](https://github.com/appcelerator/titanium-karma-client/issues/12)
* [titanium_mobile](https://github.com/appcelerator/titanium_mobile/issues/10544)
* [titanium-mobile-mocha-suite](https://github.com/appcelerator/titanium-mobile-mocha-suite/issues/107)