### PR TITLE
Ignore unused variables starting with _

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = {
 		'no-unmodified-loop-condition':  'error',
 		'no-unneeded-ternary':           'error',
 		'no-unused-expressions':         [ 'warn', { 'allowShortCircuit': true, 'allowTernary': true } ],
-		'no-unused-vars':                'warn',
+		'no-unused-vars':                [ 'warn', { 'argsIgnorePattern': '^_', 'varsIgnorePattern': '^_' } ],
 		'no-useless-concat':             'error',
 		'no-useless-constructor':        'error',
 		'no-void':                       'error',

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = {
 		'no-unmodified-loop-condition':  'error',
 		'no-unneeded-ternary':           'error',
 		'no-unused-expressions':         [ 'warn', { 'allowShortCircuit': true, 'allowTernary': true } ],
-		'no-unused-vars':                [ 'warn', { 'argsIgnorePattern': '^_.+', 'varsIgnorePattern': '^_.+' } ],
+		'no-unused-vars':                [ 'warn', { 'argsIgnorePattern': '^_.+' } ],
 		'no-useless-concat':             'error',
 		'no-useless-constructor':        'error',
 		'no-void':                       'error',

--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ module.exports = {
 		'no-unmodified-loop-condition':  'error',
 		'no-unneeded-ternary':           'error',
 		'no-unused-expressions':         [ 'warn', { 'allowShortCircuit': true, 'allowTernary': true } ],
-		'no-unused-vars':                [ 'warn', { 'argsIgnorePattern': '^_', 'varsIgnorePattern': '^_' } ],
+		'no-unused-vars':                [ 'warn', { 'argsIgnorePattern': '^_.+', 'varsIgnorePattern': '^_.+' } ],
 		'no-useless-concat':             'error',
 		'no-useless-constructor':        'error',
 		'no-void':                       'error',


### PR DESCRIPTION
As variable names and argument names also serve a purpose as comments, I think it's better to allow `_` prefixing to suppress the unused rule. This is a pattern used by other languages themselves, as it provides a clearer code style.

For example, if I have a callback of `(err, result)`, but I only use `err`, I either have to remove `result` from the arguments, or do the annoying `(err/*, result*/)`. With this change we can simply do `(err, _result)`. 