### PR TITLE
feat: set maxBOF option to 0 for no-multiple-empty-lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ module.exports = {
 		'no-lonely-if':                  'error',
 		'no-loop-func':                  'error',
 		'no-multi-str':                  'error',
-		'no-multiple-empty-lines':       [ 'error', { 'max': 1 } ],
+		'no-multiple-empty-lines':       [ 'error', { 'max': 1, 'maxBOF': 0 } ],
 		'no-new-func':                   'error',
 		'no-new-object':                 'error',
 		'no-new-require':                'error',


### PR DESCRIPTION
This PR adds a subjective option change to the `no-multiple-empty-lines` rule to ensure there are no empty lines at the beginning of a file