### PR TITLE
feat: Ignore max-len for lines with template literals

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = {
 		'linebreak-style':               [ 'error', 'unix' ],
 		'lines-around-comment':          [ 'error', { 'beforeBlockComment': false } ],
 		'max-depth':                     [ 'warn', 5 ],
-		'max-len':                       [ 'error', 200, { 'ignoreStrings': true, 'ignoreTrailingComments': true } ],
+		'max-len':                       [ 'error', 200, { 'ignoreStrings': true, 'ignoreTemplateLiterals': true, 'ignoreTrailingComments': true } ],
 		'max-nested-callbacks':          'error',
 		'max-statements-per-line':       'error',
 		'new-parens':                    'error',


### PR DESCRIPTION
This PR enables the `ignoreTemplateLiterals` option to the `max-len` rule, so we no longer get max-len errors for lines that use template literals. We already disable it for lines with strings, so disabling it for template literals makes sense to me.