### PR TITLE
Babel eslint updates

### DIFF
--- a/+babel.js
+++ b/+babel.js
@@ -2,11 +2,16 @@
 /* eslint-disable quote-props */
 var verifyPeer = require('./verify-peer-dependency');
 verifyPeer('@babel/eslint-parser');
+verifyPeer('@babel/eslint-plugin');
 
 module.exports = {
 	'parser': '@babel/eslint-parser',
 	'parserOptions': {
 		'ecmaVersion': 2020,
 		'requireConfigFile': false
+	},
+	'plugins': [ '@babel' ],
+	'rules': {
+		'@babel/semi': 'off'
 	}
 };

--- a/+babel.js
+++ b/+babel.js
@@ -1,11 +1,12 @@
 'use strict';
 /* eslint-disable quote-props */
 var verifyPeer = require('./verify-peer-dependency');
-verifyPeer('babel-eslint');
+verifyPeer('@babel/eslint-parser');
 
 module.exports = {
-	'parser': 'babel-eslint',
+	'parser': '@babel/eslint-parser',
 	'parserOptions': {
-		'ecmaVersion': 2018
+		'ecmaVersion': 2020,
+		'requireConfigFile': false
 	}
 };

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2017-2018 by Axway, Inc.
+Copyright 2017-2021 by Axway, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 	},
 	"optionalPeerDependencies": {
 		"@babel/eslint-parser": "7.x",
+		"@babel/eslint-plugin": "7.x",
 		"@typescript-eslint/parser": "1.x || 2.x || 3.x || 4.x",
 		"@typescript-eslint/eslint-plugin": "1.x || 2.x || 3.x || 4.x",
 		"eslint-plugin-alloy": "1.x",

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
 	],
 	"main": "./index.js",
 	"dependencies": {
-		"eslint-plugin-chai-expect": "^2.1.0",
-		"eslint-plugin-import": "^2.20.2",
+		"eslint-plugin-chai-expect": "^2.2.0",
+		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-node": "^11.1.0",
-		"eslint-plugin-promise": "^4.2.1",
+		"eslint-plugin-promise": "^4.3.1",
 		"eslint-plugin-security": "^1.4.0",
 		"find-root": "^1.1.0",
-		"semver": "^7.3.2"
+		"semver": "^7.3.4"
 	},
 	"optionalPeerDependencies": {
+		"@babel/eslint-parser": "7.x",
 		"@typescript-eslint/parser": "1.x || 2.x || 3.x || 4.x",
 		"@typescript-eslint/eslint-plugin": "1.x || 2.x || 3.x || 4.x",
-		"babel-eslint": "7.x || 8.x || 9.x || 10.x",
 		"eslint-plugin-alloy": "1.x",
 		"eslint-plugin-chai-friendly": "0.x",
 		"eslint-plugin-jsx-a11y": "6.x",


### PR DESCRIPTION
* Replace babel-eslint with @babel/eslint-parser.
* Update ECMAScript eslint version to 2020.
* Updated npm deps.