### PR TITLE
v6.0.1

### DIFF
--- a/+babel.js
+++ b/+babel.js
@@ -1,6 +1,7 @@
 'use strict';
 /* eslint-disable quote-props */
 var verifyPeer = require('./verify-peer-dependency');
+verifyPeer('@babel/core');
 verifyPeer('@babel/eslint-parser');
 verifyPeer('@babel/eslint-plugin');
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v6.0.1 (Mar 15, 2021)
+
+ * fix: Added `@babel/core` as an optional peer dependency so that the Babel eslint parser will
+   function properly.
+
 # v6.0.0 (Mar 3, 2021)
 
  * BREAKING CHANGE: Replaced the deprecated `babel-eslint` with `@babel/eslint-parser` and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-axway",
-	"version": "6.0.0",
+	"version": "6.0.1",
 	"description": "Shareable eslint config for Axway projects",
 	"main": "./index.js",
 	"author": "Axway, Inc. <npmjs@appcelerator.com>",
@@ -35,6 +35,7 @@
 		"semver": "^7.3.4"
 	},
 	"optionalPeerDependencies": {
+		"@babel/core": "7.x",
 		"@babel/eslint-parser": "7.x",
 		"@babel/eslint-plugin": "7.x",
 		"@typescript-eslint/parser": "4.x",


### PR DESCRIPTION
fix: Added @babel/core as an optional peer dependency so that the Babel eslint parser will function properly.