### PR TITLE
feat: support newer version of eslint-plugin-mocha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-axway",
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"eslint-plugin-alloy": "1.x",
 		"eslint-plugin-chai-friendly": "0.x",
 		"eslint-plugin-jsx-a11y": "6.x",
-		"eslint-plugin-mocha": "8.x",
+		"eslint-plugin-mocha": "8.x || 9.x",
 		"eslint-plugin-react": "7.x"
 	},
 	"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-axway",
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"description": "Shareable eslint config for Axway projects",
 	"main": "./index.js",
 	"author": "Axway, Inc. <npmjs@appcelerator.com>",


### PR DESCRIPTION
Adds eslint-plugin-mocha 9.x to the allowed list