### PR TITLE
v8.0.0 changelog updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.0.0 (Feb 28, 2023)
+
+ * BREAKING CHANGE: Replaces unmaintained `eslint-plugin-node` with `eslint-plugin-n`. Any uses of `env-node` with `node/` scoped rule overrides will need to be replaced as `n/` scoped.
+ * chore: Updated dependencies.
+
 # v7.0.1 (May 18, 2022)
 
  * fix: Ignore unsupported ES module syntax warnings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,16 +18,16 @@
 				"semver": "^7.3.8"
 			},
 			"devDependencies": {
-				"eslint": "^8.34.0"
+				"eslint": "^8.35.0"
 			},
 			"peerDependencies": {
 				"eslint": "8.x"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
+			"integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -44,6 +44,14 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
+			"integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw==",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -470,11 +478,12 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.34.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-			"integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
+			"integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.4.1",
+				"@eslint/eslintrc": "^2.0.0",
+				"@eslint/js": "8.35.0",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -488,7 +497,7 @@
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
 				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
@@ -777,9 +786,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
+			"integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -2064,9 +2073,9 @@
 	},
 	"dependencies": {
 		"@eslint/eslintrc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
-			"integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
+			"integrity": "sha512-fluIaaV+GyV24CCu/ggiHdV+j4RNh85yQnAYS/G2mZODZgGmmlrgCydjUcV3YvxCm9x8nMAfThsqTni4KiXT4A==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -2078,6 +2087,11 @@
 				"minimatch": "^3.1.2",
 				"strip-json-comments": "^3.1.1"
 			}
+		},
+		"@eslint/js": {
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.35.0.tgz",
+			"integrity": "sha512-JXdzbRiWclLVoD8sNUjR443VVlYqiYmDVT6rGUEIEHU5YJW0gaVZwV2xgM7D4arkvASqD0IlLUVjHiFuxaftRw=="
 		},
 		"@humanwhocodes/config-array": {
 			"version": "0.11.8",
@@ -2383,11 +2397,12 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 		},
 		"eslint": {
-			"version": "8.34.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
-			"integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
+			"version": "8.35.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.35.0.tgz",
+			"integrity": "sha512-BxAf1fVL7w+JLRQhWl2pzGeSiGqbWumV4WNvc9Rhp6tiCtm4oHnyPBSEtMGZwrQgudFQ+otqzWoPB7x+hxoWsw==",
 			"requires": {
-				"@eslint/eslintrc": "^1.4.1",
+				"@eslint/eslintrc": "^2.0.0",
+				"@eslint/js": "8.35.0",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -2401,7 +2416,7 @@
 				"eslint-utils": "^3.0.0",
 				"eslint-visitor-keys": "^3.3.0",
 				"espree": "^9.4.0",
-				"esquery": "^1.4.0",
+				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
@@ -2612,9 +2627,9 @@
 			}
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
+			"integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
 			"requires": {
 				"estraverse": "^5.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"eslint": "8.x"
 	},
 	"devDependencies": {
-		"eslint": "^8.34.0"
+		"eslint": "^8.35.0"
 	},
 	"scripts": {
 		"lint": "eslint .",


### PR DESCRIPTION
This PR adds changelog items for the v8.0.0 release (dated today, assuming we tag and release after this merges).
Also included is another eslint dev dep bump because of course a new one is released soon after the recent round of dep dumps...